### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/library/keywords.txt
+++ b/library/keywords.txt
@@ -16,7 +16,7 @@ readData	KEYWORD2
 getHumidity	KEYWORD2
 getHumidityInt	KEYWORD2
 getTemperatureC	KEYWORD2
-getTemperatureCInt KEYWORD2
+getTemperatureCInt	KEYWORD2
 clockReset	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords